### PR TITLE
fix: resolve ESO validation errors

### DIFF
--- a/eks-cluster-addons/environments/default/addons/external-secrets/resources/charts/external-secrets-resources/templates/externalsecret.yaml
+++ b/eks-cluster-addons/environments/default/addons/external-secrets/resources/charts/external-secrets-resources/templates/externalsecret.yaml
@@ -3,7 +3,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.externalSecret.name }}
-  namespace: {{ .Values.externalSecret.sourceNamespace }}
+  namespace: {{ .Values.externalSecret.targetNamespace }}
   labels:
     {{- include "external-secrets-resources.labels" . | nindent 4 }}
     {{- with .Values.externalSecret.labels }}
@@ -21,9 +21,9 @@ spec:
   secretStoreRef:
     name: {{ .Values.secretStore.name }}
     kind: SecretStore
+    namespace: {{ .Values.externalSecret.sourceNamespace }}
   target:
     name: {{ .Values.externalSecret.secret.k8sSecretName }}
-    namespace: {{ .Values.externalSecret.targetNamespace }}
     creationPolicy: Owner
     template:
       type: {{ .Values.externalSecret.secret.secretType }}

--- a/eks-cluster-addons/environments/default/addons/external-secrets/resources/charts/external-secrets-resources/templates/secretstore.yaml
+++ b/eks-cluster-addons/environments/default/addons/external-secrets/resources/charts/external-secrets-resources/templates/secretstore.yaml
@@ -25,5 +25,4 @@ spec:
         jwt:
           serviceAccountRef:
             name: {{ .Values.serviceAccount.name }}
-            namespace: {{ .Values.serviceAccount.namespace }}
 {{- end }}


### PR DESCRIPTION
- Remove namespace from SecretStore serviceAccountRef (not allowed for namespaced SecretStore)
- Remove target.namespace from ExternalSecret (field not declared in schema)
- ExternalSecret now created in target namespace with cross-namespace SecretStore reference