### PR TITLE
fix: use ClusterSecretStore for cross-namespace access

### DIFF
--- a/eks-cluster-addons/environments/default/addons/external-secrets/resources/charts/external-secrets-resources/templates/clustersecretstore.yaml
+++ b/eks-cluster-addons/environments/default/addons/external-secrets/resources/charts/external-secrets-resources/templates/clustersecretstore.yaml
@@ -1,9 +1,8 @@
 {{- if .Values.secretStore.create }}
 apiVersion: external-secrets.io/v1beta1
-kind: SecretStore
+kind: ClusterSecretStore
 metadata:
   name: {{ .Values.secretStore.name }}
-  namespace: {{ .Values.secretStore.namespace }}
   labels:
     {{- include "external-secrets-resources.labels" . | nindent 4 }}
     {{- with .Values.secretStore.labels }}
@@ -25,4 +24,5 @@ spec:
         jwt:
           serviceAccountRef:
             name: {{ .Values.serviceAccount.name }}
+            namespace: {{ .Values.serviceAccount.namespace }}
 {{- end }}

--- a/eks-cluster-addons/environments/default/addons/external-secrets/resources/charts/external-secrets-resources/templates/externalsecret-target.yaml
+++ b/eks-cluster-addons/environments/default/addons/external-secrets/resources/charts/external-secrets-resources/templates/externalsecret-target.yaml
@@ -2,7 +2,7 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ .Values.externalSecret.name }}
+  name: {{ .Values.externalSecret.name }}-target
   namespace: {{ .Values.externalSecret.targetNamespace }}
   labels:
     {{- include "external-secrets-resources.labels" . | nindent 4 }}
@@ -20,8 +20,7 @@ spec:
   refreshInterval: {{ .Values.externalSecret.secret.refreshInterval }}
   secretStoreRef:
     name: {{ .Values.secretStore.name }}
-    kind: SecretStore
-    namespace: {{ .Values.externalSecret.sourceNamespace }}
+    kind: ClusterSecretStore
   target:
     name: {{ .Values.externalSecret.secret.k8sSecretName }}
     creationPolicy: Owner


### PR DESCRIPTION
- Replace SecretStore with ClusterSecretStore to allow cross-namespace access
- Create ExternalSecret in target namespace (eso-test-app)
- Remove problematic namespace references that caused validation errors
- ClusterSecretStore allows ServiceAccount namespace reference
- ExternalSecret can now access ClusterSecretStore from any namespace